### PR TITLE
Update kernel.py

### DIFF
--- a/mysql_kernel/kernel.py
+++ b/mysql_kernel/kernel.py
@@ -47,6 +47,7 @@ class MysqlKernel(Kernel):
             for v in sql.split(";"):
                 v = v.rstrip()
                 l = v.lower()
+                l = l.replace('\t',' ').replace('\n',' ')
                 if len(l)>0:
                     if l.startswith('mysql://'):
                         if l.count('@')>1:


### PR DESCRIPTION
Support writting SQL with spaces or new lines.
### Issue
Using the original version resulted an error: (pymysql.err.ProgrammingError) ... , 'Cancelled', 'Shipped') LIMIT 20 limit 1000], with the code below
```sql
   ...
    'Cancelled',
    'Shipped')
LIMIT
    20;
```
### Cause
`' limit ' not in l` is not smart enough to detect '/n' or '/t' as separator.
```python
...
if l.startswith('select ') and ' limit ' not in l:
...
```
### Fix
Convert any '/n' or '/t' to ' '
```python
...
l = l.replace('\t',' ').replace('\n',' ')
...
```
